### PR TITLE
mdo(1): Added extensive group setting options and --print-rule

### DIFF
--- a/usr.bin/mdo/mdo.c
+++ b/usr.bin/mdo/mdo.c
@@ -5,9 +5,11 @@
  */
 
 #include <sys/limits.h>
+#include <sys/types.h>
 #include <sys/ucred.h>
 
 #include <err.h>
+#include <grp.h>
 #include <paths.h>
 #include <pwd.h>
 #include <stdbool.h>
@@ -26,14 +28,21 @@ usage(void)
 int
 main(int argc, char **argv)
 {
-	struct passwd *pw;
+	struct passwd *pw = NULL;
 	const char *username = "root";
+	const char *primary_group;
+	const char *supp_groups_str;
 	struct setcred wcred = SETCRED_INITIALIZER;
 	u_int setcred_flags = 0;
 	bool uidonly = false;
 	int ch;
 
-	while ((ch = getopt(argc, argv, "u:i")) != -1) {
+	gid_t *supp_groups;
+	size_t supp_count = 0;
+	gid_t gid = -1;
+	bool override_gid = false;
+
+	while ((ch = getopt(argc, argv, "u:ig:G:")) != -1) {
 		switch (ch) {
 		case 'u':
 			username = optarg;
@@ -41,30 +50,104 @@ main(int argc, char **argv)
 		case 'i':
 			uidonly = true;
 			break;
+		case 'g':
+			primary_group = optarg;
+			break;
+		case 'G':
+			supp_groups_str = optarg;
+			break;
 		default:
 			usage();
 		}
 	}
+
+	if (uidonly && (primary_group || supp_groups_str))
+		errx(EXIT_FAILURE, "-i cannot be used with -g and -G");
+
 	argc -= optind;
 	argv += optind;
 
-	if ((pw = getpwnam(username)) == NULL) {
-		if (strspn(username, "0123456789") == strlen(username)) {
-			const char *errp = NULL;
-			uid_t uid = strtonum(username, 0, UID_MAX, &errp);
-			if (errp != NULL)
-				err(EXIT_FAILURE, "invalid user ID '%s'",
-				    username);
-			pw = getpwuid(uid);
+	//uid_t target_uid = getuid();
+	gid_t target_gid = getgid();
+
+	if (username) {
+		if ((pw = getpwnam(username)) == NULL) {
+			if (strspn(username, "0123456789") == strlen(username)) {
+				const char *errp = NULL;
+				uid_t uid = strtonum(username, 0, UID_MAX, &errp);
+				if (errp != NULL)
+					err(EXIT_FAILURE, "invalid user ID '%s'",
+						username);
+				pw = getpwuid(uid);
+			}
+			if (pw == NULL)
+				err(EXIT_FAILURE, "invalid username '%s'", username);
 		}
-		if (pw == NULL)
-			err(EXIT_FAILURE, "invalid username '%s'", username);
+		//target_uid = pw->pw_uid;
+		target_gid = pw->pw_gid;
 	}
 
 	wcred.sc_uid = wcred.sc_ruid = wcred.sc_svuid = pw->pw_uid;
 	setcred_flags |= SETCREDF_UID | SETCREDF_RUID | SETCREDF_SVUID;
 
-	if (!uidonly) {
+	if (primary_group) {
+		struct group *gr = getgrnam(primary_group);
+		if (gr)
+			gid = gr->gr_gid;
+		else {
+			const char *errp = NULL;
+			gid = strtonum(primary_group, 0, GID_MAX, &errp);
+			if (errp != NULL)
+				err(EXIT_FAILURE, "invalid group '%s'", primary_group);
+		}
+		override_gid = true;
+	} else if (!uidonly && pw) {
+		gid = target_gid;
+		override_gid = true;
+	}
+
+	if (override_gid) {
+		wcred.sc_gid = wcred.sc_rgid = wcred.sc_svgid = gid;
+		setcred_flags |= SETCREDF_GID | SETCREDF_RGID | SETCREDF_SVGID;
+	}
+
+	if (supp_groups_str) {
+		char *groups_copy = strdup(supp_groups_str);
+		if (!groups_copy)
+			err(EXIT_FAILURE, "malloc failed");
+
+		size_t alloc = 16;
+		supp_groups = malloc(sizeof(gid_t) * alloc);
+		if (!supp_groups)
+			err(EXIT_FAILURE, "malloc failed");
+
+		char *token = strtok(groups_copy, ",");
+		while (token) {
+			if (supp_count >= alloc) {
+				alloc *= 2;
+				supp_groups = realloc(supp_groups, sizeof(gid_t) * alloc);
+				if (!supp_groups)
+					err(EXIT_FAILURE, "realloc failed");
+			}
+			struct group *gr = getgrnam(token);
+			if (gr)
+				supp_groups[supp_count++] = gr->gr_gid;
+			else {
+				const char *errp = NULL;
+				gid_t g = strtonum(token, 0, GID_MAX, &errp);
+				if (errp != NULL)
+					err(EXIT_FAILURE, "invalid supplementary group '%s'", token);
+				supp_groups[supp_count++] = g;
+			}
+			token = strtok(NULL, ",");
+		}
+
+		free(groups_copy);
+		wcred.sc_supp_groups = supp_groups;
+		wcred.sc_supp_groups_nb = supp_count;
+		setcred_flags |= SETCREDF_SUPP_GROUPS;
+
+	} else if (!uidonly && pw) {
 		/*
 		 * If there are too many groups specified for some UID, setting
 		 * the groups will fail.  We preserve this condition by
@@ -74,7 +157,7 @@ main(int argc, char **argv)
 		 * setcred() to actually check for overflow.
 		 */
 		const long ngroups_alloc = sysconf(_SC_NGROUPS_MAX) + 2;
-		gid_t *const groups = malloc(sizeof(*groups) * ngroups_alloc);
+		gid_t *groups = malloc(sizeof(*groups) * ngroups_alloc);
 		int ngroups = ngroups_alloc;
 
 		if (groups == NULL)
@@ -82,11 +165,9 @@ main(int argc, char **argv)
 
 		getgrouplist(pw->pw_name, pw->pw_gid, groups, &ngroups);
 
-		wcred.sc_gid = wcred.sc_rgid = wcred.sc_svgid = pw->pw_gid;
 		wcred.sc_supp_groups = groups + 1;
 		wcred.sc_supp_groups_nb = ngroups - 1;
-		setcred_flags |= SETCREDF_GID | SETCREDF_RGID | SETCREDF_SVGID |
-		    SETCREDF_SUPP_GROUPS;
+		setcred_flags |= SETCREDF_SUPP_GROUPS;
 	}
 
 	if (setcred(setcred_flags, &wcred, sizeof(wcred)) != 0)

--- a/usr.bin/mdo/mdo.c
+++ b/usr.bin/mdo/mdo.c
@@ -20,8 +20,33 @@
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: mdo [-u username] [-i] [-g primary] [-G supplementary] [-s add/remove supplementary] [--] [command [args]]\n");
-	exit(EXIT_FAILURE);
+	fprintf(stderr,
+		"Usage: mdo [options] [--] [command [args...]]\n"
+		"\n"
+		"Options:\n"
+		"  -u <user>       Target user (name or UID)\n"
+		"  -i              Only change UID, skip groups\n"
+		"  -g <group>      Override primary group (name or GID)\n"
+		"  -G <g1,g2,...>  Set supplementary groups (name or GID list)\n"
+		"  -s <mods>       Modify supplementary groups using:\n"
+		"                   +group to add, -group to remove, @ to reset\n"
+		"\n"
+		"Advanced UID/GID overrides:\n"
+		"  -U <ruid>       Set real UID\n"
+		"  -R <svuid>      Set saved UID\n"
+		"  -E <euid>       Set effective UID\n"
+		"  -P <rgid>       Set real GID\n"
+		"  -Q <svgid>      Set saved GID\n"
+		"\n"
+		"  -h              Show this help message\n"
+		"\n"
+		"Examples:\n"
+		"  mdo -u alice id\n"
+		"  mdo -u 1001 -g wheel -G staff,operator /bin/sh\n"
+		"  mdo -u bob -s @,+wheel,+operator /usr/bin/id\n"
+		"  mdo -E 1002 -R 1003 -U 1004 /bin/id\n"
+	);
+	exit(1);
 }
 
 int

--- a/usr.bin/mdo/mdo.c
+++ b/usr.bin/mdo/mdo.c
@@ -44,7 +44,9 @@ main(int argc, char **argv)
 	gid_t *supp_add = NULL, *supp_rem = NULL;
 	size_t add_count = 0, rem_count = 0;
 
-	while ((ch = getopt(argc, argv, "u:ig:G:s:")) != -1) {
+	const char *ruid_str = NULL, *svuid_str = NULL, *euid_str = NULL, *rgid_str = NULL, *svgid_str = NULL;
+
+	while ((ch = getopt(argc, argv, "u:ig:G:s:U:R:E:P:Q:")) != -1) {
 		switch (ch) {
 		case 'u':
 			username = optarg;
@@ -60,6 +62,21 @@ main(int argc, char **argv)
 			break;
 		case 's':
 			group_mod_str = optarg;
+			break;
+		case 'U':
+			ruid_str = optarg;
+			break;
+		case 'R':
+			svuid_str = optarg;
+			break;
+		case 'E':
+			euid_str = optarg;
+			break;
+		case 'P':
+			rgid_str = optarg;
+			break;
+		case 'Q':
+			svgid_str = optarg;
 			break;
 		default:
 			usage();
@@ -88,6 +105,42 @@ main(int argc, char **argv)
 
 	wcred.sc_uid = wcred.sc_ruid = wcred.sc_svuid = pw->pw_uid;
 	setcred_flags |= SETCREDF_UID | SETCREDF_RUID | SETCREDF_SVUID;
+
+	if (ruid_str) {
+		const char *errp = NULL;
+		wcred.sc_ruid = strtonum(ruid_str, 0, UID_MAX, &errp);
+		if (errp)
+			err(EXIT_FAILURE, "-U: invalid UID");
+		setcred_flags |= SETCREDF_RUID;
+	}
+	if (svuid_str) {
+		const char *errp = NULL;
+		wcred.sc_svuid = strtonum(svuid_str, 0, UID_MAX, &errp);
+		if (errp)
+			err(EXIT_FAILURE, "-U: invalid UID");
+		setcred_flags |= SETCREDF_SVUID;
+	}
+	if (euid_str) {
+		const char *errp = NULL;
+		wcred.sc_uid = strtonum(euid_str, 0, UID_MAX, &errp);
+		if (errp)
+			err(EXIT_FAILURE, "-U: invalid UID");
+		setcred_flags |= SETCREDF_UID;
+	}
+	if (rgid_str) {
+		const char *errp = NULL;
+		wcred.sc_rgid = strtonum(rgid_str, 0, GID_MAX, &errp);
+		if (errp)
+			err(EXIT_FAILURE, "-U: invalid GID");
+		setcred_flags |= SETCREDF_RGID;
+	}
+	if (svgid_str) {
+		const char *errp = NULL;
+		wcred.sc_svuid = strtonum(svgid_str, 0, GID_MAX, &errp);
+		if (errp)
+			err(EXIT_FAILURE, "-U: invalid GID");
+		setcred_flags |= SETCREDF_SVGID;
+	}
 
 	if (primary_group) {
 		struct group *gr = getgrnam(primary_group);


### PR DESCRIPTION
Added options to:
1) set primary group (-g)
2) override supplementary groups (-G)
3) add, remove or reset supplementary groups (-s [+,-,@])
4) override Real UID (-U), saved UID (-R), effective UID (-E), real GID (-P), saved GID (-Q)
5) print the actual transition rules that will occur (--print-rule)